### PR TITLE
Add "bin"-reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.4.2",
   "description": "Source code documentation generator for Javascript, LESS and CSS",
   "main": "doxydoc.js",
+  "bin": {
+    "doxydoc": "bin/doxydoc"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:AndiOxidant/doxydoc.git"


### PR DESCRIPTION
The reference to the `bin/doxydoc`-file in `package.json` is needed to put the program into the PATH on `npm -g install doxydoc`
